### PR TITLE
Add dataset description in datalad-tabby format

### DIFF
--- a/.datalad/tabby/self/authors@tby-crc1451v0.tsv
+++ b/.datalad/tabby/self/authors@tby-crc1451v0.tsv
@@ -1,0 +1,7 @@
+name	email	orcid	affiliation
+Vahid Rostami			Computational Systems Neuroscience, Institute of Zoology, University of Cologne
+Thomas Rost			Computational Systems Neuroscience, Institute of Zoology, University of Cologne
+Felix Schmitt			Computational Systems Neuroscience, Institute of Zoology, University of Cologne
+Alexa Riehle		0000-0001-5890-3999	Institut de Neurosciences de la Timone
+Sacha van Albada		0000-0003-0682-4855	FZ Juelich
+Martin Nawrot			Computational Systems Neuroscience, Institute of Zoology, University of Cologne

--- a/.datalad/tabby/self/data-controller@tby-crc1451v0.tsv
+++ b/.datalad/tabby/self/data-controller@tby-crc1451v0.tsv
@@ -1,0 +1,2 @@
+name	email	type
+Martin Nawrot	mnawrot@uni-koeln.de	Person

--- a/.datalad/tabby/self/dataset@tby-crc1451v0.tsv
+++ b/.datalad/tabby/self/dataset@tby-crc1451v0.tsv
@@ -1,0 +1,7 @@
+name	ClusteredNetwork_pub
+title	Spiking Attractor Model of Motor Cortex: Modulating Neural and Behavioral Variability via Prior Target Information
+description	This DataLad dataset contains a variant of the analysis described by Rostami et al. in https://doi.org/10.21203/rs.3.rs-1337724/v1 (Spiking Attractor Model of Motor Cortex: Modulating Neural and Behavioral Variability via Prior Target Information). It focuses on demonstrating computational reproducibility and contains a subset of original results.
+crc-project	A06	INF
+sample[organism]	NCBITaxon:9544
+sample[organism-part]	UBERON:0001384	UBERON:0016634
+keywords	Motor cortex	Delayed center-out task

--- a/.datalad/tabby/self/funding@tby-crc1451v0.tsv
+++ b/.datalad/tabby/self/funding@tby-crc1451v0.tsv
@@ -1,0 +1,4 @@
+funder	grant
+DFG	431549029-A06
+German Excellence Initiative (DFG-ZUK)	81/1
+EU	https://cordis.europa.eu/project/id/945539

--- a/.datalad/tabby/self/publications@tby-crc1451v0.tsv
+++ b/.datalad/tabby/self/publications@tby-crc1451v0.tsv
@@ -1,0 +1,2 @@
+doi
+https://doi.org/10.21203/rs.3.rs-1337724/v1


### PR DESCRIPTION
The author list from the [preprint](https://doi.org/10.21203/rs.3.rs-1337724/v1) is combined with the list of contributors from the [original GitHub repo](https://github.com/nawrotlab/ClusteredNetwork_pub) to form the dataset author list.

Information on funding, and other information, is taken (as well as possible) from the preprint.